### PR TITLE
Fix for authorContributionStatement data storage

### DIFF
--- a/cfg/cfg.d/zz_ref_support.pl
+++ b/cfg/cfg.d/zz_ref_support.pl
@@ -713,7 +713,7 @@ $c->add_dataset_field( 'ref_support_selection', { name => 'output_sub_profile_ca
 $c->add_dataset_field( 'ref_support_selection', { name => 'author_statement', type => 'boolean' }, reuse => 1 );
 
 # authorContributionStatement
-$c->add_dataset_field( 'ref_support_selection', { name => 'author_statement_text', type => 'text' }, reuse => 1 );
+$c->add_dataset_field( 'ref_support_selection', { name => 'author_statement_text', type => 'longtext' }, reuse => 1 );
 
 # excludeFromSubmission
 $c->add_dataset_field( 'ref_support_selection', { name => 'exclude_from_submission', type => 'boolean' }, reuse=> 1 );


### PR DESCRIPTION
The authorContributionStatement can be up to 7500 characters in
length but the existing field definition could only store up
to 255 characters.

This patch changes it to a longtext field.